### PR TITLE
Add ability to auto-update scores via cron job

### DIFF
--- a/includes/application_top.php
+++ b/includes/application_top.php
@@ -52,7 +52,7 @@ $login = new Login;
 $adminUser = $login->get_user('admin');
 //print_r($adminUser);
 
-$okFiles = array('login.php', 'signup.php', 'password_reset.php');
+$okFiles = array('login.php', 'signup.php', 'password_reset.php', 'getHtmlScores.php');
 if (!in_array(basename($_SERVER['PHP_SELF']), $okFiles) && (empty($_SESSION['logged']) || $_SESSION['logged'] !== 'yes')) {
 	header( 'Location: login.php' );
 	exit;

--- a/includes/config.php
+++ b/includes/config.php
@@ -19,5 +19,16 @@ define('SEASON_YEAR', '2015');
 //set timezone offset, hours difference between your server's timezone and eastern
 define('SERVER_TIMEZONE_OFFSET', 0);
 
+//define a batch update "key" that a cronjob can pass to update scores automatically
+//can be anything you want, as long as it can be sent as a get parameter on the URL
+//NOTE: make your life easier and just use alpha-numerics w/out any special chars...
+//NOTE: THE PAGE NAME IS CASE SENSEITVE TO BYPASS LOG-IN, IF THE CASE NOT MATCH, IT WILL REDIRECT TO LOGIN W/OUT UPDATING SCORES!
+//example:
+// curl -O 'http://www.yourdomain.com/getHtmlScores.php?BATCH_SCORE_UPDATE_KEY=yourRandomDefinedValueHere'
+// wget 'http://www.yourdomain.com/getHtmlScores.php?BATCH_SCORE_UPDATE_KEY=yourRandomDefinedValueHere'
+define('BATCH_SCORE_UPDATE_KEY', 'f5fe57a1950f903a420e6c43cc266f62');
+//enable or disable batch updates here
+define('BATCH_SCORE_UPDATE_ENABLED', true);
+
 // ***DO NOT EDIT ANYTHING BELOW THIS LINE***
 error_reporting(E_ALL ^ E_NOTICE ^ E_STRICT);

--- a/includes/config.php
+++ b/includes/config.php
@@ -26,7 +26,7 @@ define('SERVER_TIMEZONE_OFFSET', 0);
 //example:
 // curl -O 'http://www.yourdomain.com/getHtmlScores.php?BATCH_SCORE_UPDATE_KEY=yourRandomDefinedValueHere'
 // wget 'http://www.yourdomain.com/getHtmlScores.php?BATCH_SCORE_UPDATE_KEY=yourRandomDefinedValueHere'
-define('BATCH_SCORE_UPDATE_KEY', 'f5fe57a1950f903a420e6c43cc266f62');
+define('BATCH_SCORE_UPDATE_KEY', '1234567890abcdefghijklmnopqrstuvwxyz');
 //enable or disable batch updates here
 define('BATCH_SCORE_UPDATE_ENABLED', true);
 


### PR DESCRIPTION
With these changes, I can now update scores automatically via a cron job without having to manually log in and update.

For example, my cronjob to update every 15 minutes on Monday/Thursday/Sunday after 12pm-12am

```
*/15 12-23 * * 1,4,7 curl --silent 'http://www.yourdomain.com/getHtmlScores.php?BATCH_SCORE_UPDATE_KEY=yourRandomDefinedValueHere' >> ~/cronlog.txt
```
